### PR TITLE
[feature] Limit the resource usage of zookeeper containers

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/zookeeper/k8s/zookeeper-server.yaml.ftl
+++ b/cloudeon-stack/EDP-1.0.0/zookeeper/k8s/zookeeper-server.yaml.ftl
@@ -45,6 +45,10 @@ spec:
           value: "/opt/edp/${service.serviceName}/conf"
         - name: USER
           value: ${runAs}
+        - name: MEM_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
         image: "${dockerImage}"
         imagePullPolicy: "Always"
         readinessProbe:
@@ -60,8 +64,12 @@ spec:
           timeoutSeconds: 15
         name: "${roleServiceFullName}"
         resources:
-          requests: {}
-          limits: {}
+          requests:
+            memory: "${conf['zookeeper.container.request.memory']}Mi"
+            cpu: "${conf['zookeeper.container.request.cpu']}"
+          limits:
+            memory: "${conf['zookeeper.container.limit.memory']}Mi"
+            cpu: "${conf['zookeeper.container.limit.cpu']}"
         securityContext:
           privileged: true
         volumeMounts:

--- a/cloudeon-stack/EDP-1.0.0/zookeeper/render/zookeeper-env.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/zookeeper/render/zookeeper-env.sh.ftl
@@ -6,8 +6,9 @@ export ZOOPIDFILE="/opt/edp/${service.serviceName}/data/zookeeper-server.pid"
 
 export SERVER_JVMFLAGS="-Dcom.sun.management.jmxremote.port=${conf['zookeeper.jmxremote.port']} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false"
 
-<#assign memory = conf['zookeeper.server.memory']?number>
-export SERVER_JVMFLAGS="-Xmx${memory?floor?c}m $SERVER_JVMFLAGS"
+<#assign ramPercentage = conf['zookeeper.jvm.memory.percentage']?number>
+# 优先使用zk内置的环境变量，用于设置Xmx，单位为m
+export ZK_SERVER_HEAP=$[ $MEM_LIMIT / 1024 / 1024  * ${ramPercentage} / 100 ]
 
 export SERVER_JVMFLAGS="-Dzookeeper.log.dir=/opt/edp/${service.serviceName}/log -Dzookeeper.root.logger=INFO,ROLLINGFILE $SERVER_JVMFLAGS"
 

--- a/cloudeon-stack/EDP-1.0.0/zookeeper/service-info.yaml
+++ b/cloudeon-stack/EDP-1.0.0/zookeeper/service-info.yaml
@@ -35,6 +35,44 @@ customConfigFiles:
 
 configurations:
 
+  - name: zookeeper.container.limit.cpu
+    description: "Zookeeper Server容器的CPU使用限额"
+    recommendExpression: 1.0
+    valueType: InputNumber
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: zookeeper.container.limit.memory
+    description: "Zookeeper Server容器的内存使用限额，单位MB"
+    recommendExpression: 2048
+    valueType: InputNumber
+    unit: Mi
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: zookeeper.container.request.cpu
+    description: "Zookeeper Server容器的CPU请求量"
+    recommendExpression: 0.2
+    valueType: InputNumber
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: zookeeper.container.request.memory
+    description: "Zookeeper Server容器的内存请求量，单位MB"
+    recommendExpression: 1024
+    valueType: InputNumber
+    unit: Mi
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: zookeeper.jvm.memory.percentage
+    description: "Zookeeper Server JVM占容器内存限额的百分比"
+    recommendExpression: 75
+    valueType: InputNumber
+    unit: ".0"
+    configurableInWizard: true
+    tag: "资源管理"
+
   - name: zookeeper.peer.communicate.port
     recommendExpression: 2888
     valueType: InputNumber
@@ -59,6 +97,7 @@ configurations:
   - name: zookeeper.jmxremote.port
     recommendExpression: 9911
     valueType: InputNumber
+    configurableInWizard: true
     tag: "端口"
 
 
@@ -93,16 +132,6 @@ configurations:
     valueType: InputNumber
     confFile: "zoo.cfg"
     tag: "常用参数"
-
-
-  - name: zookeeper.server.memory
-    recommendExpression: 1024
-    valueType: InputNumber
-    unit: MB
-    configurableInWizard: true
-    tag: "资源管理"
-
-
 
   - name: sasl.oauth2.enabled
     recommendExpression: true


### PR DESCRIPTION
[[Feature] Limit the resource usage of containers. #54](https://github.com/dromara/CloudEon/issues/54)

## Brief changelog
1.Limit the resource usage of zookeeper containers. 
2.Use percentage instead of specific values to configure zookeeper jvm memory.

