### PR TITLE
fix: Invalid license header of ScriptRunner

### DIFF
--- a/cloudeon-server/src/main/java/org/dromara/cloudeon/utils/ScriptRunner.java
+++ b/cloudeon-server/src/main/java/org/dromara/cloudeon/utils/ScriptRunner.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2004-2020 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
-
 package org.dromara.cloudeon.utils;
 
 import java.io.IOException;


### PR DESCRIPTION
## What is the purpose of the change

Fix the license header of `cloudeon-server/src/main/java/org/dromara/cloudeon/utils/ScriptRunner.java`, otherwise, it fails the mvn compile command `mvn clean install -DskipTests`

```
[INFO] Replacing main artifact with repackaged archive
[INFO]
[INFO] --- license-maven-plugin:4.2:check (default) @ cloudeon-server ---
[INFO] Checking licenses...
[WARNING] Missing header in: /home/chengpan/Projects/CloudEon/cloudeon-server/src/main/java/org/dromara/cloudeon/utils/ScriptRunner.java
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for cloudeon v1.0.0:
[INFO]
[INFO] cloudeon ........................................... SUCCESS [ 12.489 s]
[INFO] cloudeon-ui ........................................ SUCCESS [03:47 min]
[INFO] cloudeon-server .................................... FAILURE [02:03 min]
[INFO] cloudeon-assembly .................................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:10 min
[INFO] Finished at: 2023-06-12T17:21:30+08:00
```

## Brief changelog

- Fix the license header of `cloudeon-server/src/main/java/org/dromara/cloudeon/utils/ScriptRunner.java` by `mvn license:format`

## Verifying this change

Do I need to test?
Has testing been completed?
Test method?

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 3 checklist before request the community to review your PR`.

- [ ] Make sure there is a [Github issue](https://github.com/dromara/CloudEon/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Follow the git commit specification
    * feat: xxx ->      The feat type is used to identify production changes related to new backward-compatible abilities or functionality.
    * perf: xxx ->      The perf type is used to identify production changes related to backward-compatible performance improvements.
    * fix: xxx  ->      The fix type is used to identify production changes related to backward-compatible bug fixes.
    * docs: xxx ->      The docs type is used to identify documentation changes related to the project - whether intended externally for the end users (in case of a library) or internally for the developers.
    * test: xxx ->      The test type is used to identify development changes related to tests - such as refactoring existing tests or adding new tests.
    * refactor: xxx ->  The refactor type is used to identify development changes related to modifying the codebase, which neither adds a feature nor fixes a bug - such as removing redundant code, simplifying the code, renaming variables, etc.
   
                    