### PR TITLE
[feature] Limit the resource usage of elasticsearch containers

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/elasticsearch/k8s/elasticsearch-node.yaml.ftl
+++ b/cloudeon-stack/EDP-1.0.0/elasticsearch/k8s/elasticsearch-node.yaml.ftl
@@ -51,8 +51,12 @@ spec:
           timeoutSeconds: 2
         name: "${roleServiceFullName}"
         resources:
-          requests: {}
-          limits: {}
+          requests:
+            memory: "${conf['elasticsearch.container.request.memory']}Mi"
+            cpu: "${conf['elasticsearch.container.request.cpu']}"
+          limits:
+            memory: "${conf['elasticsearch.container.limit.memory']}Mi"
+            cpu: "${conf['elasticsearch.container.limit.cpu']}"
         securityContext:
           privileged: true
         volumeMounts:

--- a/cloudeon-stack/EDP-1.0.0/elasticsearch/render/bootstrap-elasticsearch.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/elasticsearch/render/bootstrap-elasticsearch.sh.ftl
@@ -2,6 +2,7 @@
 
 export ES_PATH_CONF="/opt/edp/${service.serviceName}/conf"
 
+export ES_JAVA_HOME=$ELASTICSEARCH_HOME/elasticsearch/jdk
 elasticsearch -d
 nohup /home/hadoop/elasticsearch_exporter/elasticsearch_exporter --es.all --es.indices --es.cluster_settings --es.node="test" --es.indices_settings --es.shards --es.snapshots --es.timeout=5s --web.listen-address ":${conf['elasticsearch.exporter.port']}" --web.telemetry-path "/metrics" --es.ssl-skip-verify --es.clusterinfo.interval=5m --es.uri http://${localhostname}:${conf['elasticsearch.http.listeners.port']} > /opt/edp/${service.serviceName}/log/elasticsearch_exporter.log 2>&1 &
 

--- a/cloudeon-stack/EDP-1.0.0/elasticsearch/render/jvm.options.ftl
+++ b/cloudeon-stack/EDP-1.0.0/elasticsearch/render/jvm.options.ftl
@@ -30,11 +30,6 @@
 ## directory containing these lines:
 ##
 
-<#assign esInitalMemory=conf['elasticsearch.node.inital.memory']?trim?number>
-<#assign esMaxMemory=conf['elasticsearch.node.max.memory']?trim?number>
-
--Xms${esInitalMemory?floor?c}g
--Xmx${esMaxMemory?floor?c}g
 ##
 ## See https://www.elastic.co/guide/en/elasticsearch/reference/8.5/heap-size.html
 ## for more information

--- a/cloudeon-stack/EDP-1.0.0/elasticsearch/service-info.yaml
+++ b/cloudeon-stack/EDP-1.0.0/elasticsearch/service-info.yaml
@@ -33,6 +33,37 @@ customConfigFiles:
   - jvm.options
 
 configurations:
+
+  - name: elasticsearch.container.limit.cpu
+    description: "Elasticsearch Server容器的CPU使用限额"
+    recommendExpression: 1.0
+    valueType: InputNumber
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: elasticsearch.container.limit.memory
+    description: "Elasticsearch Server容器的内存使用限额，单位MB"
+    recommendExpression: 2048
+    valueType: InputNumber
+    unit: Mi
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: elasticsearch.container.request.cpu
+    description: "Elasticsearch Server容器的CPU请求量"
+    recommendExpression: 0.2
+    valueType: InputNumber
+    configurableInWizard: true
+    tag: "资源管理"
+
+  - name: elasticsearch.container.request.memory
+    description: "Elasticsearch Server容器的内存请求量，单位MB"
+    recommendExpression: 1024
+    valueType: InputNumber
+    unit: Mi
+    configurableInWizard: true
+    tag: "资源管理"
+
   - name: elasticsearch.http.listeners.port
     recommendExpression: 9200
     valueType: InputNumber
@@ -59,23 +90,3 @@ configurations:
     configurableInWizard: true
     description: "Elasticsearch exporter metrics端口"
     tag: "端口"
-
-  - name: elasticsearch.node.inital.memory
-    recommendExpression: 4
-    min: 1
-    max: 10
-    valueType: Slider
-    unit: GB
-    configurableInWizard: true
-    description: "Elasticsearch 初始堆内存,单位GB"
-    tag: "资源管理"
-
-  - name: elasticsearch.node.max.memory
-    recommendExpression: 4
-    min: 1
-    max: 64
-    valueType: Slider
-    unit: GB
-    configurableInWizard: true
-    description: "Elasticsearch 最大堆内存,单位GB"
-    tag: "资源管理"


### PR DESCRIPTION
[[Feature] Limit the resource usage of containers. #54](https://github.com/dromara/CloudEon/issues/54)
## What is the purpose of the change

Limit the resource usage of elasticsearch containers.

## Brief changelog

1. Remove Xms Xmx settings : By default, Elasticsearch automatically sets the JVM heap size based on a node’s [roles](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/modules-node.html#node-roles) and total memory. Using the default sizing is recommended for most production environments.
2. Use the bundled jdk:  Automatic heap sizing requires the [bundled JDK](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/setup.html#jvm-version) or, if using a custom JRE location, a Java 14 or later JRE.

## Verifying this change

Do I need to test?
yes
Has testing been completed?
yes
Test method?

```shell
jps
$ELASTICSEARCH_HOME/elasticsearch/jdk/bin/jinfo $PID
```

                    