### PR TITLE
[feature] Limit the resource usage of kafka containers

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/kafka/k8s/kafka-broker.yaml.ftl
+++ b/cloudeon-stack/EDP-1.0.0/kafka/k8s/kafka-broker.yaml.ftl
@@ -52,8 +52,17 @@ spec:
           timeoutSeconds: 2
         name: "${roleServiceFullName}"
         resources:
-          requests: {}
-          limits: {}
+          requests:
+            memory: "${conf['kafka.container.request.memory']}Mi"
+            cpu: "${conf['kafka.container.request.cpu']}"
+          limits:
+            memory: "${conf['kafka.container.limit.memory']}Mi"
+            cpu: "${conf['kafka.container.limit.cpu']}"
+        env:
+          - name: MEM_LIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
         securityContext:
           privileged: true
         volumeMounts:

--- a/cloudeon-stack/EDP-1.0.0/kafka/render/bootstrap-kafkaserver.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/kafka/render/bootstrap-kafkaserver.sh.ftl
@@ -2,8 +2,16 @@
 
 
 export LOG_DIR="/opt/edp/${service.serviceName}/log"
+<#assign heapRamPercentage = conf['kafka.server.heap.memory.percentage']?number>
+<#assign directRamPercentage = conf['kafka.server.direct.memory.percentage']?number>
+export heapRam=$[ $MEM_LIMIT / 1024 / 1024  * ${heapRamPercentage} / 100 ]M
+export directRam=$[ $MEM_LIMIT / 1024 / 1024  * ${directRamPercentage} / 100 ]M
 
-export KAFKA_OPTS="$KAFKA_OPTS -Xmx${conf['kafka.server.memory']?number?floor?c}m -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9921 -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-0.14.0.jar=5551:/opt/edp/${service.serviceName}/conf/jmx_prometheus.yaml"
+# 环境变量由kafka-run-class.sh注入
+export JMX_PORT=${conf['kafka.jmx.port']}
+export KAFKA_HEAP_OPTS="-Xmx$heapRam -Xms$heapRam -XX:MaxDirectMemorySize=$directRam"
+
+export KAFKA_OPTS="$KAFKA_OPTS -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-0.14.0.jar=5551:/opt/edp/${service.serviceName}/conf/jmx_prometheus.yaml"
 
 kafka-server-start.sh  /opt/edp/${service.serviceName}/conf/server.properties
 

--- a/cloudeon-stack/EDP-1.0.0/kafka/service-info.yaml
+++ b/cloudeon-stack/EDP-1.0.0/kafka/service-info.yaml
@@ -35,13 +35,54 @@ configurations:
   - name: "kafka.listeners.port"
     recommendExpression: 9092
     valueType: InputNumber
+    configurableInWizard: true
     description: "Kafka监听端口"
     tag: "端口"
-  - name: "kafka.server.memory"
+  - name: "kafka.jmx.port"
+    recommendExpression: 9921
+    valueType: InputNumber
+    configurableInWizard: true
+    description: "Kafka JMX监听端口"
+    tag: "端口"
+  - name: kafka.container.limit.cpu
+    description: "Kafka Server容器的CPU使用限额"
+    recommendExpression: 1.0
+    valueType: InputNumber
+    configurableInWizard: true
+    tag: "资源管理"
+  - name: kafka.container.limit.memory
+    description: "Kafka Server容器的内存使用限额，单位MB"
     recommendExpression: 2048
     valueType: InputNumber
-    unit: MB
-    description: "Kafka 最大堆内存,单位MB"
+    unit: Mi
+    configurableInWizard: true
+    tag: "资源管理"
+  - name: kafka.container.request.cpu
+    description: "Kafka Server容器的CPU请求量"
+    recommendExpression: 0.2
+    valueType: InputNumber
+    configurableInWizard: true
+    tag: "资源管理"
+  - name: kafka.container.request.memory
+    description: "Kafka Server容器的内存请求量，单位MB"
+    recommendExpression: 1024
+    valueType: InputNumber
+    unit: Mi
+    configurableInWizard: true
+    tag: "资源管理"
+  - name: kafka.server.heap.memory.percentage
+    description: "Kafka Server 堆内存占容器内存限额的百分比，用于Kafka jvm，需预留内存供pagecache使用"
+    recommendExpression: 25
+    valueType: InputNumber
+    unit: ".0"
+    configurableInWizard: true
+    tag: "资源管理"
+  - name: kafka.server.direct.memory.percentage
+    description: "Kafka Server 直接内存占容器内存限额的百分比，用于Kafka 网络IO，需预留内存供pagecache使用"
+    recommendExpression: 25
+    valueType: InputNumber
+    unit: ".0"
+    configurableInWizard: true
     tag: "资源管理"
   - name: "num.partitions"
     recommendExpression: 8
@@ -149,6 +190,29 @@ configurations:
     description: "socket每次请求的最大字节数"
     confFile:  "server.properties"
     unit: bytes
+    tag: "性能"
+  - name: "log.flush.interval.messages"
+    recommendExpression: "1000000"
+    valueType: InputNumber
+    configurableInWizard: false
+    description: "在将消息刷新到磁盘之前，日志分区上累积的消息数，该值将影响PageCache的大小"
+    confFile:  "server.properties"
+    tag: "性能"
+  - name: "log.flush.interval.ms"
+    recommendExpression: "10000"
+    valueType: InputNumber
+    configurableInWizard: false
+    description: "任何主题中的消息在刷新到磁盘之前保存在内存中的最长时间(以毫秒为单位)，该值将影响PageCache的大小"
+    confFile:  "server.properties"
+    unit: ms
+    tag: "性能"
+  - name: "log.flush.scheduler.interval.ms"
+    recommendExpression: "10000"
+    valueType: InputNumber
+    configurableInWizard: false
+    description: "日志刷新程序检查是否需要将日志刷新到磁盘的频率(以毫秒为单位)，该值将影响PageCache的大小"
+    confFile:  "server.properties"
+    unit: ms
     tag: "性能"
   - name: "zookeeper.connection.timeout.ms"
     recommendExpression: "18000"


### PR DESCRIPTION
[[Feature] Limit the resource usage of containers. #54](https://github.com/dromara/CloudEon/issues/54)
## What is the purpose of the change

Limit the resource usage of kafka containers.

## Brief changelog
1.Limit the resource usage of kafka containers.
2.Add flush-related parameters to control the memory usage of the page cache.
3.Add kafka.jmx.port parameter
                    