### PR TITLE
fix:#85 add necessary jar to dinky classpath

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/dinky/render/bootstrap-dinky.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/dinky/render/bootstrap-dinky.sh.ftl
@@ -8,7 +8,7 @@ DINKY_CONF=/opt/edp/${service.serviceName}/conf
 
 cp $FLINK_HOME/lib/flink-* $DINKY_HOME/plugins/flink$FLINK_VERSION/
 
-CLASS_PATH="$DINKY_HOME/lib/*:config:$DINKY_HOME/plugins/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/*"
+CLASS_PATH="$DINKY_HOME/lib/*:config:$DINKY_HOME/plugins/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/dinky/*"
 
 JAVA_OPTS="-server -Ddruid.mysql.usePingMethod=false -Duser.timezone=$SPRING_JACKSON_TIME_ZONE -Xms1g -Xmx1g -Xmn512m -XX:+PrintGCDetails -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof  -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9927 -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-0.14.0.jar=5558:/opt/edp/${service.serviceName}/conf/jmx_prometheus.yaml"
 

--- a/cloudeon-stack/EDP-1.0.0/dinky/render/bootstrap-dinky.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/dinky/render/bootstrap-dinky.sh.ftl
@@ -8,7 +8,7 @@ DINKY_CONF=/opt/edp/${service.serviceName}/conf
 
 cp $FLINK_HOME/lib/flink-* $DINKY_HOME/plugins/flink$FLINK_VERSION/
 
-CLASS_PATH="$DINKY_HOME/lib/*:config:$DINKY_HOME/plugins/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/dinky/*"
+CLASS_PATH="$DINKY_HOME/lib/*:config:$DINKY_HOME/plugins/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/*:$DINKY_HOME/plugins/flink$FLINK_VERSION/dinky/*"
 
 JAVA_OPTS="-server -Ddruid.mysql.usePingMethod=false -Duser.timezone=$SPRING_JACKSON_TIME_ZONE -Xms1g -Xmx1g -Xmn512m -XX:+PrintGCDetails -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof  -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9927 -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-0.14.0.jar=5558:/opt/edp/${service.serviceName}/conf/jmx_prometheus.yaml"
 


### PR DESCRIPTION
## What is the purpose of the change
fix CloudEon issue #85 

## Brief changelog
Modify dinky bootstrap-dinky.sh.ftl , and add necessary jar to the classpath. 

## Verifying this change
I tested on the CloudEon environment and dinky was able to submit tasks normally
   
        