### PR TITLE
修复安装dinky，SQL脚本找不到

### DIFF
--- a/cloudeon-server/src/main/java/org/dromara/cloudeon/processor/InitDinkyDBTask.java
+++ b/cloudeon-server/src/main/java/org/dromara/cloudeon/processor/InitDinkyDBTask.java
@@ -56,7 +56,7 @@ public class InitDinkyDBTask extends BaseCloudeonTask {
         String url = configRepository.findByServiceInstanceIdAndName(serviceInstanceId, "jdbc.mysql.address").getValue();
         DataSource ds = new SimpleDataSource(url, username, password);
 
-        String dinkySqlPath = stackLoadPath+ File.separator+ stackServiceEntity.getStackCode() + File.separator + stackServiceEntity.getName() + File.separator + "sql" + File.separator + "dinky.sql";
+        String dinkySqlPath = stackLoadPath+ File.separator+ stackServiceEntity.getStackCode() + File.separator + stackServiceEntity.getName().toLowerCase() + File.separator + "sql" + File.separator + "dinky.sql";
         try (Connection conn = ds.getConnection()) {
             FileInputStream sqlFileStream = new FileInputStream(dinkySqlPath);
             ScriptRunner initScriptRunner = new ScriptRunner(conn, true, true,log);

--- a/cloudeon-server/src/main/java/org/dromara/cloudeon/processor/InitDinkyDBTask.java
+++ b/cloudeon-server/src/main/java/org/dromara/cloudeon/processor/InitDinkyDBTask.java
@@ -54,10 +54,12 @@ public class InitDinkyDBTask extends BaseCloudeonTask {
         String username = configRepository.findByServiceInstanceIdAndName(serviceInstanceId, "jdbc.mysql.username").getValue();
         String password = configRepository.findByServiceInstanceIdAndName(serviceInstanceId, "jdbc.mysql.password").getValue();
         String url = configRepository.findByServiceInstanceIdAndName(serviceInstanceId, "jdbc.mysql.address").getValue();
-        DataSource ds = new SimpleDataSource(url, username, password);
 
         String dinkySqlPath = stackLoadPath+ File.separator+ stackServiceEntity.getStackCode() + File.separator + stackServiceEntity.getName().toLowerCase() + File.separator + "sql" + File.separator + "dinky.sql";
-        try (Connection conn = ds.getConnection()) {
+        try (
+                SimpleDataSource ds = new SimpleDataSource(url, username, password);
+                Connection conn = ds.getConnection()
+        ) {
             FileInputStream sqlFileStream = new FileInputStream(dinkySqlPath);
             ScriptRunner initScriptRunner = new ScriptRunner(conn, true, true,log);
             Reader initSqlReader = new InputStreamReader(sqlFileStream);


### PR DESCRIPTION
## What is the purpose of the change
1. 修复安装dinky，SQL脚本找不到
2. 优化dinky初始化数据库过程中，数据源使用try-with-resources关闭
