### PR TITLE
[feature] Hadoop datanode supports multiple data directory configurations

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/hdfs/render/hadoop-hdfs-env.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/hdfs/render/hadoop-hdfs-env.sh.ftl
@@ -105,5 +105,5 @@ export JOURNALNODE_RPC_PORT=${conf['journalnode.rpc-port']}
 export DATANODE_DATA_DIRS=/opt/edp/${service.serviceName}/data/datanode
 
 # Export dfs.namenode.name.dir
-export NAMENODE_DATA_DIRS=/opt/edp/${service.serviceName}/data/namenode
+export DATANODE_DATA_DIRS=${conf['dfs.datanode.data.dir']}
 

--- a/cloudeon-stack/EDP-1.0.0/hdfs/render/hdfs-site.xml.ftl
+++ b/cloudeon-stack/EDP-1.0.0/hdfs/render/hdfs-site.xml.ftl
@@ -48,7 +48,7 @@
 </#if>
 
 <#--handle data dir-->
-<@property "dfs.datanode.data.dir" "/opt/edp/${serviceName}/data/datanode"/>
+<@property "dfs.datanode.data.dir" "${conf['dfs.datanode.data.dir']}"/>
 <@property "dfs.namenode.name.dir" "/opt/edp/${serviceName}/data/namenode"/>
 <@property "dfs.journalnode.edits.dir" "/opt/edp/${serviceName}/data/journal"/>
 

--- a/cloudeon-stack/EDP-1.0.0/hdfs/service-info.yaml
+++ b/cloudeon-stack/EDP-1.0.0/hdfs/service-info.yaml
@@ -192,7 +192,7 @@ configurations:
     tag: "常用参数"
 
 
-- name: dfs.datanode.data.dir
+  - name: dfs.datanode.data.dir
     recommendExpression: /opt/edp/hdfs/data/datanode
     valueType: InputString
     description: HDFS数据目录，多个目录使用","分割。子目录需在/opt/edp/hdfs/data目录下，提前创建需设置为sshd用户。

--- a/cloudeon-stack/EDP-1.0.0/hdfs/service-info.yaml
+++ b/cloudeon-stack/EDP-1.0.0/hdfs/service-info.yaml
@@ -192,6 +192,15 @@ configurations:
     tag: "常用参数"
 
 
+- name: dfs.datanode.data.dir
+    recommendExpression: /opt/edp/hdfs/data/datanode
+    valueType: InputString
+    description: HDFS数据目录，多个目录使用","分割。子目录需在/opt/edp/hdfs/data目录下，提前创建需设置为sshd用户。
+    confFile:  "hdfs-site.xml"
+    configurableInWizard: true
+    tag: "常用参数"
+
+
   - name: dfs.datanode.data.dir.perm
     recommendExpression: 755
     valueType: InputNumber


### PR DESCRIPTION
## What is the purpose of the change

Hadoop datanode supports multiple data directory configurations

## Brief changelog

[fix-123](https://github.com/dromara/CloudEon/issues/123)

## Verifying this change

<img width="1437" alt="image" src="https://github.com/dromara/CloudEon/assets/20313983/4cdb19e5-61ed-4ee7-aef7-bf706ab343e6">

<img width="1116" alt="image" src="https://github.com/dromara/CloudEon/assets/20313983/ac5ebef2-da0e-47c0-9279-f07177f302bc">

![image](https://github.com/dromara/CloudEon/assets/20313983/e05df785-18f0-4a2f-af04-13b661fdaab7)

                    