### PR TITLE
[Improve] upgrade dinky to 0.7.5.

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/dinky/docker/Dockerfile
+++ b/cloudeon-stack/EDP-1.0.0/dinky/docker/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt
 ARG FLINK_VERSION=1.15.4
 ARG FLINK_BIG_VERSION=1.15
 ARG SCALA_VERSION=2.12
-ARG DINKY_VERSION=0.7.3
+ARG DINKY_VERSION=0.7.5
 ARG HADOOP_VERSION=3.3.4
 
 RUN wget   https://github.com/DataLinkDC/dinky/releases/download/v${DINKY_VERSION}/dlink-release-${DINKY_VERSION}.tar.gz  &&  tar zxvf dlink-release-${DINKY_VERSION}.tar.gz -C /opt && rm -f dlink-release-${DINKY_VERSION}.tar.gz \

--- a/cloudeon-stack/EDP-1.0.0/dinky/docker/build.sh
+++ b/cloudeon-stack/EDP-1.0.0/dinky/docker/build.sh
@@ -1,11 +1,11 @@
 
 
-docker build -f Dockerfile -t dinky:0.7.3 .
-docker tag   dinky:0.7.3  registry.cn-hangzhou.aliyuncs.com/udh/dinky:0.7.3
-docker push registry.cn-hangzhou.aliyuncs.com/udh/dinky:0.7.3
+docker build -f Dockerfile -t dinky:0.7.5 .
+docker tag   dinky:0.7.5  registry.cn-hangzhou.aliyuncs.com/udh/dinky:0.7.5
+docker push registry.cn-hangzhou.aliyuncs.com/udh/dinky:0.7.5
 
-docker tag   registry.cn-hangzhou.aliyuncs.com/udh/dinky:0.7.3  registry.mufankong.top/udh/dinky:0.7.3
-docker push  registry.mufankong.top/udh/dinky:0.7.3
+docker tag   registry.cn-hangzhou.aliyuncs.com/udh/dinky:0.7.5  registry.mufankong.top/udh/dinky:0.7.5
+docker push  registry.mufankong.top/udh/dinky:0.7.5
 
 
-docker tag  dinky:0.7.3 172.16.129.68:5000/dinky:0.7.3
+docker tag  dinky:0.7.5 172.16.129.68:5000/dinky:0.7.5

--- a/cloudeon-stack/EDP-1.0.0/dinky/render/bootstrap-dinky.sh.ftl
+++ b/cloudeon-stack/EDP-1.0.0/dinky/render/bootstrap-dinky.sh.ftl
@@ -22,7 +22,7 @@ rm -rf plugins/flink1.14
 rm -rf plugins/flink1.16
 rm -rf plugins/flink1.17
 
-cp jar/dlink-app-$FLINK_BIG_VERSION-0.7.3-jar-with-dependencies.jar  dlink-app.jar
+cp jar/dlink-app-$FLINK_BIG_VERSION-$DINKY_VERSION-jar-with-dependencies.jar  dlink-app.jar
 hdfs dfs -mkdir -p  /dlink/jar/
 hdfs dfs -put dlink-app.jar /dlink/jar/
 rm -rf dlink-app.jar


### PR DESCRIPTION
升级dinky0.7.5版本能够支持更多的flink配置参数。比如:
'jdbc.properties.tinyInt1isBit' = 'false',
'jdbc.properties.transformedBitIsBoolean' = 'false',
这两个参数在数据库同步时非常重要，它能解决mysql的Bit自动转换为flink的boolean类型问题。