### PR TITLE
把doris 版本升级到1.2.4.1

### DIFF
--- a/cloudeon-stack/EDP-1.0.0/doris/docker/Dockerfile
+++ b/cloudeon-stack/EDP-1.0.0/doris/docker/Dockerfile
@@ -5,10 +5,13 @@ USER doris
 
 WORKDIR /home/doris/
 
-RUN wget https://archive.apache.org/dist/doris/1.1/1.1.5-rc02/apache-doris-fe-1.1.5-bin-x86_64.tar.xz && tar -xvf apache-doris-fe-1.1.5-bin-x86_64.tar.xz -C /home/doris/ \
-    && rm -f apache-doris-fe-1.1.5-bin-x86_64.tar.xz && mv apache-doris-fe-1.1.5-bin-x86_64  doris-fe  \
-     && wget https://archive.apache.org/dist/doris/1.1/1.1.5-rc02/apache-doris-be-1.1.5-bin-x86_64.tar.xz \
-    && tar -xvf apache-doris-be-1.1.5-bin-x86_64.tar.xz -C /home/doris/   && rm -f apache-doris-be-1.1.5-bin-x86_64.tar.xz && mv apache-doris-be-1.1.5-bin-x86_64  doris-be
+RUN wget https://archive.apache.org/dist/doris/1.2/1.2.4.1-rc01/apache-doris-fe-1.2.4.1-bin-x86_64.tar.xz && tar -xvf apache-doris-fe-1.2.4.1-bin-x86_64.tar.xz -C /home/doris/ \
+    && rm -f apache-doris-fe-1.2.4.1-bin-x86_64.tar.xz && mv apache-doris-fe-1.2.4.1-bin-x86_64  doris-fe  \
+     && wget https://archive.apache.org/dist/doris/1.2/1.2.4.1-rc01/apache-doris-be-1.2.4.1-bin-x86_64.tar.xz \
+    && tar -xvf apache-doris-be-1.2.4.1-bin-x86_64.tar.xz -C /home/doris/   && rm -f apache-doris-be-1.2.4.1-bin-x86_64.tar.xz && mv apache-doris-be-1.2.4.1-bin-x86_64  doris-be
+
+RUN wget https://archive.apache.org/dist/doris/1.2/1.2.4.1-rc01/apache-doris-dependencies-1.2.4.1-bin-x86_64.tar.xz && tar -xvf apache-doris-dependencies-1.2.4.1-bin-x86_64.tar.xz -C /home/doris/   \
+    && rm -f apache-doris-dependencies-1.2.4.1-bin-x86_64.tar.xz && cp -r apache-doris-dependencies-1.2.4.1-bin-x86_64/*  /home/doris/doris-be/lib/
 
 
 

--- a/cloudeon-stack/EDP-1.0.0/doris/docker/build.sh
+++ b/cloudeon-stack/EDP-1.0.0/doris/docker/build.sh
@@ -1,6 +1,6 @@
-docker build -f Dockerfile -t doris:1.1.5 .
-docker tag doris:1.1.5 registry.cn-hangzhou.aliyuncs.com/udh/doris:1.1.5
-docker push registry.cn-hangzhou.aliyuncs.com/udh/doris:1.1.5
+docker build -f Dockerfile -t doris:1.2.4.1 .
+docker tag doris:1.2.4.1 registry.cn-hangzhou.aliyuncs.com/udh/doris:1.2.4.1
+docker push registry.cn-hangzhou.aliyuncs.com/udh/doris:1.2.4.1
 
 #docker tag doris:1.1.5 registry.mufankong.top/udh/doris:1.1.5
 #docker push  registry.mufankong.top/udh/doris:1.1.5

--- a/cloudeon-stack/EDP-1.0.0/doris/render/be.conf.ftl
+++ b/cloudeon-stack/EDP-1.0.0/doris/render/be.conf.ftl
@@ -6,7 +6,9 @@ PPROF_TMPDIR="/opt/edp/${service.serviceName}/log"
 # since 1.2, the JAVA_HOME need to be set to run BE process.
 # JAVA_HOME=/path/to/jdk/
 
-priority_networks = ${localhostip}
+JAVA_HOME=/opt/jdk1.8.0_141/
+
+priority_networks = ${localhostip}/24
 
 
 storage_root_path = /opt/edp/${service.serviceName}/data

--- a/cloudeon-stack/EDP-1.0.0/doris/render/be_bootstrap.sh
+++ b/cloudeon-stack/EDP-1.0.0/doris/render/be_bootstrap.sh
@@ -2,6 +2,7 @@
 basedir=$(cd `dirname $0`/..; pwd)
 sysctl -w vm.max_map_count=2000000
 $DORIS_HOME/doris-be/bin/start_be.sh --daemon
+$DORIS_HOME/doris-be/lib/apache_hdfs_broker/bin/start_broker.sh --daemon
 
 tail -f /dev/null
 

--- a/cloudeon-stack/EDP-1.0.0/doris/service-info.yaml
+++ b/cloudeon-stack/EDP-1.0.0/doris/service-info.yaml
@@ -1,8 +1,8 @@
 name: DORIS
 label: "Doris"
 description: "实时OLAP分析系统"
-version: 1.1.5
-dockerImage: "registry.cn-hangzhou.aliyuncs.com/udh/doris:1.1.5"
+version: 1.2.4.1
+dockerImage: "registry.cn-hangzhou.aliyuncs.com/udh/doris:1.2.4.1"
 dependencies: []
 
 runAs: doris


### PR DESCRIPTION
修改了
![oNnJbrhl6S](https://github.com/dromara/CloudEon/assets/3173937/0d364b12-e86d-43c1-95cb-1ada72f04a83)

cloudEon-stack/EDP-1.0.0/doris 下面的
docker(build.sh ,Dockerfile),render(be.conf.ftl,be_bootstrap.sh) service-info.yaml 等5个文件，
