### PR TITLE
更新 kube-prometheus-stack 镜像配置

### DIFF
--- a/cloudeon-stack/EDP-2.0.0/kube-prometheus-stack/docker/build.sh
+++ b/cloudeon-stack/EDP-2.0.0/kube-prometheus-stack/docker/build.sh
@@ -1,0 +1,6 @@
+```shell
+docker pull grafana/grafana:11.4.0
+docker tag grafana/grafana:11.4.0 registry.cn-guangzhou.aliyuncs.com/bigdata200/grafana:11.4.0
+docker push registry.cn-guangzhou.aliyuncs.com/bigdata200/grafana:11.4.0
+
+```

--- a/cloudeon-stack/EDP-2.0.0/kube-prometheus-stack/k8s/kube-prometheus-stack.yaml.ftl
+++ b/cloudeon-stack/EDP-2.0.0/kube-prometheus-stack/k8s/kube-prometheus-stack.yaml.ftl
@@ -32,6 +32,12 @@ spec:
       serviceMonitor:
         cAdvisorMetricRelabelings: ""
     grafana:
+      image:
+        registry: registry.cn-guangzhou.aliyuncs.com
+        repository: bigdata200/grafana
+        # Overrides the Grafana image tag whose default is the chart appVersion
+        tag: "11.4.0"
+        pullPolicy: IfNotPresent
       sidecar:
         dashboards:
           provider:

--- a/cloudeon-stack/EDP-2.0.0/kube-prometheus-stack/service-info.yaml
+++ b/cloudeon-stack/EDP-2.0.0/kube-prometheus-stack/service-info.yaml
@@ -125,8 +125,9 @@ configurations:
     tag: "grafana"
 
   - name: image.registry.proxy.k8s
-    description: "该参数用于将helm用到的registry.k8s.io修改为目标值，避免因网络问题拉取失败"
-    recommendExpression: "registry.k8s.io"
+    description: "该参数用于将helm用到的registry.k8s.io修改为目标值，避免因网络问题导致镜像拉取失败。可参考https://github.com/ciiiii/cloudflare-docker-proxy"
+    needChangeInWizard: false
+    recommendExpression: "k8s-gcr.libcuda.so"
     valueType: InputString
     configurableInWizard: true
     tag: "镜像"

--- a/cloudeon-stack/EDP-2.0.0/seatunnel/service-info.yaml
+++ b/cloudeon-stack/EDP-2.0.0/seatunnel/service-info.yaml
@@ -3,7 +3,7 @@ label: "Seatunnel"
 description: "海量数据同步引擎"
 version: 2.3.7
 dependencies:
-  - hdfs
+  - "HDFS"
 
 supportKerberos: false
 

--- a/cloudeon-stack/EDP-2.0.0/trino/service-info.yaml
+++ b/cloudeon-stack/EDP-2.0.0/trino/service-info.yaml
@@ -3,7 +3,7 @@ label: "Trino"
 description: "Trino是一个分布式SQL查询引擎，用于在大型数据集上执行交互式分析。"
 version: "424"
 dependencies:
-  - "hive"
+  - "HIVE"
 
 supportKerberos: false
 

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -95,6 +95,8 @@ $image \
 #### 挂载文件并运行
 
 ```
+image=registry.cn-guangzhou.aliyuncs.com/bigdata200/cloudeon:v2.0.0-beta.1
+conf_path_dir=/opt/cloudeon
 docker rm -f cloudeon
 docker run -d --name cloudeon \
  -e DB_ACTIVE=mysql \


### PR DESCRIPTION
fix: 更新 seatunnel 和 trino 依赖项名称为大写
feat: 更新 kube-prometheus-stack 配置，应对国内网络问题

- 更新 service-info.yaml，添加镜像代理说明和默认值
- 更新 kube-prometheus-stack.yaml.ftl，配置 grafana 镜像
- 添加 docker build 脚本，用于构建 grafana 镜像