### PR TITLE
improvement: Upgrade Doris to 2.1.11

### DIFF
--- a/cloudeon-stack/EDP-2.0.0/doris/docker/Dockerfile
+++ b/cloudeon-stack/EDP-2.0.0/doris/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH=$PATH:$DORIS_HOME/fe/bin:$DORIS_HOME/be/bin
 
 WORKDIR /tmp
 
-ARG DORIS_DOWNLOAD_URL=https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.1.8.1-bin-x64.tar.gz
+ARG DORIS_DOWNLOAD_URL=https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.1.11-bin-x64.tar.gz
 
 RUN wget $DORIS_DOWNLOAD_URL \
     && tar -xvf apache-doris-*.tar.gz -C /opt \

--- a/cloudeon-stack/EDP-2.0.0/doris/docker/build.sh
+++ b/cloudeon-stack/EDP-2.0.0/doris/docker/build.sh
@@ -2,9 +2,9 @@
 cat /proc/cpuinfo | grep avx2
 
 # dockerfile默认使用的是 avx2
-docker build -f Dockerfile -t registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.8.1  .
-docker push  registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.8.1
+docker build -f Dockerfile -t registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.11  .
+docker push  registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.11
 
 # 如果要使用 noavx2 或使用不同版本，在这里指定下载链接
-docker build --build-arg DORIS_DOWNLOAD_URL='https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.1.8.1-bin-x64-noavx2.tar.gz' -f Dockerfile -t registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.8.1-noavx2  .
-docker push  registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.8.1-noavx2
+docker build --build-arg DORIS_DOWNLOAD_URL='https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.1.11-bin-x64-noavx2.tar.gz' -f Dockerfile -t registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.11-noavx2  .
+docker push  registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.11-noavx2

--- a/cloudeon-stack/EDP-2.0.0/doris/service-info.yaml
+++ b/cloudeon-stack/EDP-2.0.0/doris/service-info.yaml
@@ -1,7 +1,7 @@
 name: DORIS
 label: "Doris"
 description: "基于 MPP 架构的高性能、实时分析型数据库"
-version: 2.1.8.1
+version: 2.1.11
 dependencies: []
 
 supportKerberos: false
@@ -52,7 +52,7 @@ customConfigFiles:
 configurations:
   - name: serverImage
     description: "服务镜像"
-    recommendExpression: "registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.8.1"
+    recommendExpression: "registry.cn-guangzhou.aliyuncs.com/bigdata200/doris:2.1.11"
     valueType: InputString
     configurableInWizard: true
     tag: "镜像"
@@ -265,4 +265,3 @@ configurations:
     unit: Mi
     configurableInWizard: true
     tag: "资源管理"
-


### PR DESCRIPTION
## What is the purpose of the change

Upgrade Doris to 2.1.11 to avoid the bug where running the profiler on Doris' database tables on OpenMetadata fails.